### PR TITLE
remove linear dependency

### DIFF
--- a/example/Example.hs
+++ b/example/Example.hs
@@ -8,7 +8,6 @@ import Control.Monad      (forM_)
 import Data.ByteString    (readFile)
 import Data.Text          (Text, unpack)
 import Data.Text.IO       (putStrLn)
-import Linear             (V4(..))
 import Prelude     hiding (putStrLn, readFile)
 import System.Environment (getArgs)
 import System.Exit        (exitFailure)
@@ -17,10 +16,10 @@ import qualified SDL
 import qualified SDL.Font
 
 red :: SDL.Font.Color
-red = V4 255 0 0 0
+red = SDL.V4 255 0 0 0
 
 gray :: SDL.Font.Color
-gray = V4 128 128 128 255
+gray = SDL.V4 128 128 128 255
 
 -- A sequence of example actions to be perfomed and displayed.
 examples :: [(Text, SDL.Window -> FilePath -> IO ())]

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -39,7 +39,6 @@ library
   build-depends:
     base             >= 4.7 && < 5,
     bytestring       >= 0.10.4.0,
-    linear           >= 1.10.1.2,
     sdl2             >= 2.0,
     template-haskell,
     text             >= 1.1.0.0,
@@ -62,7 +61,6 @@ executable sdl2-ttf-example
     build-depends:
       base       >= 4.7 && < 5,
       bytestring >= 0.10.4.0,
-      linear     >= 1.10.1.2,
       sdl2       >= 2.0,
       sdl2-ttf,
       text       >= 1.1.0.0

--- a/src/SDL/Font.hs
+++ b/src/SDL/Font.hs
@@ -98,9 +98,8 @@ import Foreign.Marshal.Utils  (with, fromBool, toBool)
 import Foreign.Ptr            (Ptr, castPtr, nullPtr)
 import Foreign.Storable       (peek, pokeByteOff)
 import GHC.Generics           (Generic)
-import Linear                 (V4(..))
 import SDL.ExceptionHelper
-import SDL                    (Surface(..))
+import SDL                    (Surface(..), V4(..))
 import SDL.Raw.Filesystem     (rwFromConstMem)
 
 import qualified SDL.Raw


### PR DESCRIPTION
The sdl2 bindings added a no-linear cabal flag to remove linear as a dependency.  This change is to just use the re-exported SDL V4 instance so any code using this sdl2-ttf binding isn't required to re-add the linear dependency as a result