### PR TITLE
Add a cpp-options workaround for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - cd ..
 
   # Install SDL.
-  - wget -q http://www.libsdl.org/release/SDL2-2.0.3.tar.gz
+  - wget -q http://www.libsdl.org/release/SDL2-2.0.4.tar.gz
   - tar xf SDL2-*.tar.gz
   - cd SDL2-* && ./configure && make && sudo make install && cd ..
 

--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -1,5 +1,5 @@
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_ttf.h"
+#include "SDL.h"
+#include "SDL_ttf.h"
 
 // Lots of SDL_ttf's render functions accept an SDL_Color directly. We send in
 // a pointer instead, which we dereference here. Is there a way to avoid this?

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -45,6 +45,9 @@ library
   default-language:
     Haskell2010
 
+  if os(windows)
+    cpp-options: -D_SDL_main_h
+
 flag example
   description: Build the example executable
   default:     False


### PR DESCRIPTION
This is an implementation of this hack: haskell-game/sdl2#139
I've tested that with the hack the example works fine on Linux.
I'm guessing it's needed on Windows, just as in the following cases:
https://github.com/gizmo-mk0/my-tools/blob/master/Haskell-SDL/hssdl.md
https://github.com/rongcuid/sdl2-ttf/pull/4